### PR TITLE
Fix Typo in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ This web site provides free / OER materials to help you learn the history and in
 You can take this course and receive a certificate at:
 <ul>
 <li><a href="https://www.coursera.org/learn/internet-history" target="_blank">Coursera: <?= $CFG->servicedesc ?></a> </li>
-<li><a href="https://online.umich.edu/courses/internet-history-technology-and-security/" target="_blank">Free certificates for University of Michgan students and staff</a></li>
+<li><a href="https://online.umich.edu/courses/internet-history-technology-and-security/" target="_blank">Free certificates for University of Michigan students and staff</a></li>
 <li>
 <a href="https://www.freecodecamp.org/news/learn-the-history-of-the-internet-in-dr-chucks/" target="_blank">Free Code Camp</a>
 provides this material in a single video so you can sit back


### PR DESCRIPTION
Fix to IHTS website landing page's index.php: "Michgan" typo in certification link changed to "Michigan"